### PR TITLE
KEP-5963: DRA Device Compatibility Groups (alpha)

### DIFF
--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -284,6 +284,10 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
 
+// Defines the maximum number of compatibility groups that can be
+// declared per device counter consumption.
+const ResourceSliceMaxCompatibilityGroupsPerConsumption = 8
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -492,6 +496,19 @@ type DeviceCounterConsumption struct {
 	//
 	// +required
 	Counters map[string]Counter
+
+	// CompatibilityGroups lists names of mutually-compatible groups this
+	// device belongs to for the referenced counter set. Two devices
+	// consuming from the same counter set can be co-allocated only if
+	// they share at least one group name, or if both omit the field.
+	//
+	// The relation is symmetric but not transitive.
+	// Group names are driver-defined; no cluster-wide registry is enforced.
+	//
+	// The maximum number of groups per entry is 8.
+	//
+	// +optional
+	CompatibilityGroups []string
 }
 
 // DeviceCapacity describes a quantity associated with a device.

--- a/pkg/apis/resource/v1/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1/zz_generated.conversion.go
@@ -1018,6 +1018,7 @@ func Convert_resource_DeviceConstraint_To_v1_DeviceConstraint(in *resource.Devic
 func autoConvert_v1_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in *resourcev1.DeviceCounterConsumption, out *resource.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 
@@ -1029,6 +1030,7 @@ func Convert_v1_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in
 func autoConvert_resource_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in *resource.DeviceCounterConsumption, out *resourcev1.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resourcev1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 

--- a/pkg/apis/resource/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.conversion.go
@@ -1007,6 +1007,7 @@ func Convert_resource_DeviceConstraint_To_v1beta1_DeviceConstraint(in *resource.
 func autoConvert_v1beta1_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in *resourcev1beta1.DeviceCounterConsumption, out *resource.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 
@@ -1018,6 +1019,7 @@ func Convert_v1beta1_DeviceCounterConsumption_To_resource_DeviceCounterConsumpti
 func autoConvert_resource_DeviceCounterConsumption_To_v1beta1_DeviceCounterConsumption(in *resource.DeviceCounterConsumption, out *resourcev1beta1.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resourcev1beta1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 

--- a/pkg/apis/resource/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.conversion.go
@@ -1068,6 +1068,7 @@ func Convert_resource_DeviceConstraint_To_v1beta2_DeviceConstraint(in *resource.
 func autoConvert_v1beta2_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in *resourcev1beta2.DeviceCounterConsumption, out *resource.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 
@@ -1079,6 +1080,7 @@ func Convert_v1beta2_DeviceCounterConsumption_To_resource_DeviceCounterConsumpti
 func autoConvert_resource_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumption(in *resource.DeviceCounterConsumption, out *resourcev1beta2.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resourcev1beta2.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -968,7 +968,18 @@ func validateDeviceCounterConsumption(deviceCounterConsumption resource.DeviceCo
 		allErrs = append(allErrs, validateMap(deviceCounterConsumption.Counters, resource.ResourceSliceMaxCountersPerDeviceCounterConsumption,
 			validation.DNS1123LabelMaxLength, validateCounterName, validateDeviceCounter, fldPath.Child("counters"), keysCovered)...)
 	}
+	if len(deviceCounterConsumption.CompatibilityGroups) > 0 {
+		allErrs = append(allErrs, validateSet(deviceCounterConsumption.CompatibilityGroups,
+			resource.ResourceSliceMaxCompatibilityGroupsPerConsumption,
+			validateCompatibilityGroupName,
+			stringKey,
+			fldPath.Child("compatibilityGroups"))...)
+	}
 	return allErrs
+}
+
+func validateCompatibilityGroupName(name string, fldPath *field.Path) field.ErrorList {
+	return validateCounterName(name, fldPath)
 }
 
 var (

--- a/pkg/apis/resource/zz_generated.deepcopy.go
+++ b/pkg/apis/resource/zz_generated.deepcopy.go
@@ -686,6 +686,11 @@ func (in *DeviceCounterConsumption) DeepCopyInto(out *DeviceCounterConsumption) 
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.CompatibilityGroups != nil {
+		in, out := &in.CompatibilityGroups, &out.CompatibilityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -202,6 +202,14 @@ const (
 	// enabled.
 	DRADeviceBindingConditions featuregate.Feature = "DRADeviceBindingConditions"
 
+	// owner: @omeryahud
+	// kep: https://kep.k8s.io/5963
+	//
+	// Enables DRA drivers to express mutual-compatibility constraints
+	// between devices that consume the same counter set, so the scheduler
+	// can avoid co-allocating incompatible partitioning modes.
+	DRADeviceCompatibilityGroups featuregate.Feature = "DRADeviceCompatibilityGroups"
+
 	// owner: @pohly
 	// kep: http://kep.k8s.io/5055
 	//
@@ -1294,6 +1302,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	DRADeviceCompatibilityGroups: {
+		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	DRADeviceTaintRules: {
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.36"), Default: false, PreRelease: featuregate.Beta}, // Depends on an off-by-default beta API.
@@ -2277,6 +2289,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	DRAConsumableCapacity: {DynamicResourceAllocation},
 
 	DRADeviceBindingConditions: {DynamicResourceAllocation, DRAResourceClaimDeviceStatus},
+
+	DRADeviceCompatibilityGroups: {DynamicResourceAllocation, DRAPartitionableDevices},
 
 	DRADeviceTaintRules: {DRADeviceTaints}, // DynamicResourceAllocation is indirect.
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -47322,6 +47322,25 @@ func schema_k8sio_api_resource_v1_DeviceCounterConsumption(ref common.ReferenceC
 							},
 						},
 					},
+					"compatibilityGroups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "CompatibilityGroups lists names of mutually-compatible groups this device belongs to for the referenced counter set. Two devices consuming from the same counter set can be co-allocated only if they share at least one group name, or if both omit the field.\n\nThe relation is symmetric but not transitive. Group names are driver-defined; no cluster-wide registry is enforced.\n\nThe maximum number of groups per entry is 8.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"counterSet", "counters"},
 			},
@@ -50192,6 +50211,25 @@ func schema_k8sio_api_resource_v1beta1_DeviceCounterConsumption(ref common.Refer
 							},
 						},
 					},
+					"compatibilityGroups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "CompatibilityGroups lists names of mutually-compatible groups this device belongs to for the referenced counter set. Two devices consuming from the same counter set can be co-allocated only if they share at least one group name, or if both omit the field.\n\nThe relation is symmetric but not transitive. Group names are driver-defined; no cluster-wide registry is enforced.\n\nThe maximum number of groups per entry is 8.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"counterSet", "counters"},
 			},
@@ -52437,6 +52475,25 @@ func schema_k8sio_api_resource_v1beta2_DeviceCounterConsumption(ref common.Refer
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Ref: ref(resourcev1beta2.Counter{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+					"compatibilityGroups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "CompatibilityGroups lists names of mutually-compatible groups this device belongs to for the referenced counter set. Two devices consuming from the same counter set can be co-allocated only if they share at least one group name, or if both omit the field.\n\nThe relation is symmetric but not transitive. Group names are driver-defined; no cluster-wide registry is enforced.\n\nThe maximum number of groups per entry is 8.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},

--- a/pkg/registry/resource/resourceslice/strategy.go
+++ b/pkg/registry/resource/resourceslice/strategy.go
@@ -200,6 +200,7 @@ func dropDisabledFields(newSlice, oldSlice *resource.ResourceSlice) {
 	dropDisabledDRAConsumableCapacityFields(newSlice, oldSlice)
 	dropDisabledDRANodeAllocatableResourcesFields(newSlice, oldSlice)
 	dropDisableDRAListTypeAttributesFields(newSlice, oldSlice)
+	dropDisabledDRADeviceCompatibilityGroupsFields(newSlice, oldSlice)
 }
 
 func dropDisabledDRADeviceTaintsFields(newSlice, oldSlice *resource.ResourceSlice) {
@@ -238,6 +239,32 @@ func dropDisabledDRAPartitionableDevicesFields(newSlice, oldSlice *resource.Reso
 		newSlice.Spec.Devices[i].NodeSelector = nil
 		newSlice.Spec.Devices[i].AllNodes = nil
 	}
+}
+
+func dropDisabledDRADeviceCompatibilityGroupsFields(newSlice, oldSlice *resource.ResourceSlice) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceCompatibilityGroups) ||
+		draDeviceCompatibilityGroupsFeatureInUse(oldSlice) {
+		return
+	}
+	for i := range newSlice.Spec.Devices {
+		for j := range newSlice.Spec.Devices[i].ConsumesCounters {
+			newSlice.Spec.Devices[i].ConsumesCounters[j].CompatibilityGroups = nil
+		}
+	}
+}
+
+func draDeviceCompatibilityGroupsFeatureInUse(slice *resource.ResourceSlice) bool {
+	if slice == nil {
+		return false
+	}
+	for _, device := range slice.Spec.Devices {
+		for _, cc := range device.ConsumesCounters {
+			if len(cc.CompatibilityGroups) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func dropDisabledDRADeviceBindingConditionsFields(newSlice, oldSlice *resource.ResourceSlice) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -212,6 +212,12 @@ func New(ctx context.Context, plArgs runtime.Object, fh fwk.Handle, fts feature.
 		draManager: fh.SharedDRAManager(),
 	}
 
+	if fts.EnableDRADeviceCompatibilityGroups {
+		structured.SetCompatibilityGroupRejectionRecorder(func(driver, counterSet string) {
+			schedmetrics.DRACompatibilityGroupRejectionsTotal.WithLabelValues(driver, counterSet).Inc()
+		})
+	}
+
 	return pl, nil
 }
 
@@ -655,12 +661,13 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 
 func AllocatorFeatures(fts feature.Features) structured.Features {
 	return structured.Features{
-		AdminAccess:            fts.EnableDRAAdminAccess,
-		PrioritizedList:        fts.EnableDRAPrioritizedList,
-		PartitionableDevices:   fts.EnableDRAPartitionableDevices,
-		DeviceTaints:           fts.EnableDRADeviceTaints,
-		DeviceBindingAndStatus: fts.EnableDRADeviceBindingConditions && fts.EnableDRAResourceClaimDeviceStatus,
-		ConsumableCapacity:     fts.EnableDRAConsumableCapacity,
+		AdminAccess:               fts.EnableDRAAdminAccess,
+		PrioritizedList:           fts.EnableDRAPrioritizedList,
+		PartitionableDevices:      fts.EnableDRAPartitionableDevices,
+		DeviceTaints:              fts.EnableDRADeviceTaints,
+		DeviceBindingAndStatus:    fts.EnableDRADeviceBindingConditions && fts.EnableDRAResourceClaimDeviceStatus,
+		ConsumableCapacity:        fts.EnableDRAConsumableCapacity,
+		DeviceCompatibilityGroups: fts.EnableDRADeviceCompatibilityGroups,
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -213,8 +213,8 @@ func New(ctx context.Context, plArgs runtime.Object, fh fwk.Handle, fts feature.
 	}
 
 	if fts.EnableDRADeviceCompatibilityGroups {
-		structured.SetCompatibilityGroupRejectionRecorder(func(driver, counterSet string) {
-			schedmetrics.DRACompatibilityGroupRejectionsTotal.WithLabelValues(driver, counterSet).Inc()
+		structured.SetCompatibilityGroupRejectionRecorder(func(driver string) {
+			schedmetrics.DRACompatibilityGroupRejectionsTotal.WithLabelValues(driver).Inc()
 		})
 	}
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -212,12 +212,6 @@ func New(ctx context.Context, plArgs runtime.Object, fh fwk.Handle, fts feature.
 		draManager: fh.SharedDRAManager(),
 	}
 
-	if fts.EnableDRADeviceCompatibilityGroups {
-		structured.SetCompatibilityGroupRejectionRecorder(func(driver string) {
-			schedmetrics.DRACompatibilityGroupRejectionsTotal.WithLabelValues(driver).Inc()
-		})
-	}
-
 	return pl, nil
 }
 

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -31,6 +31,7 @@ type Features struct {
 	EnableDRAConsumableCapacity                   bool
 	EnableDRADeviceTaints                         bool
 	EnableDRADeviceBindingConditions              bool
+	EnableDRADeviceCompatibilityGroups            bool
 	EnableDRAListTypeAttributes                   bool
 	EnableDRANodeAllocatableResources             bool
 	EnableDRAPartitionableDevices                 bool
@@ -67,6 +68,7 @@ func NewSchedulerFeaturesFromGates(featureGate featuregate.FeatureGate) Features
 		EnableDRASchedulerFilterTimeout:               featureGate.Enabled(features.DRASchedulerFilterTimeout),
 		EnableDRAResourceClaimDeviceStatus:            featureGate.Enabled(features.DRAResourceClaimDeviceStatus),
 		EnableDRADeviceBindingConditions:              featureGate.Enabled(features.DRADeviceBindingConditions),
+		EnableDRADeviceCompatibilityGroups:            featureGate.Enabled(features.DRADeviceCompatibilityGroups),
 		EnableDRAWorkloadResourceClaims:               featureGate.Enabled(features.DRAWorkloadResourceClaims),
 		EnableDynamicResourceAllocation:               featureGate.Enabled(features.DynamicResourceAllocation),
 		EnableVolumeAttributesClass:                   featureGate.Enabled(features.VolumeAttributesClass),

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -495,10 +495,10 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "dra_compatibility_rejections_total",
-			Help:           "Number of DRA candidate-device rejections caused by compatibility-group conflicts, labelled by driver and counter set.",
+			Help:           "Number of DRA candidate-device rejections caused by compatibility-group conflicts, labelled by driver.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"driver", "counter_set"},
+		[]string{"driver"},
 	)
 
 	GetNodeHintDuration = metrics.NewHistogramVec(

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -179,10 +179,6 @@ var (
 	DRABindingConditionsAllocationsTotal *metrics.CounterVec
 	DRABindingConditionsPreBindDuration  *metrics.HistogramVec
 
-	// DRACompatibilityGroupRejectionsTotal is only available when the
-	// DRADeviceCompatibilityGroups feature gate is enabled.
-	DRACompatibilityGroupRejectionsTotal *metrics.CounterVec
-
 	// metricsList is a list of all metrics that should be registered always, regardless of any feature gate's value.
 	metricsList []metrics.Registerable
 )
@@ -222,9 +218,6 @@ func Register() {
 				DRABindingConditionsAllocationsTotal,
 				DRABindingConditionsPreBindDuration,
 			)
-		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceCompatibilityGroups) {
-			RegisterMetrics(DRACompatibilityGroupRejectionsTotal)
 		}
 	})
 }
@@ -489,16 +482,6 @@ func InitMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"profile", "driver", "status"},
-	)
-
-	DRACompatibilityGroupRejectionsTotal = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:      SchedulerSubsystem,
-			Name:           "dra_compatibility_rejections_total",
-			Help:           "Number of DRA candidate-device rejections caused by compatibility-group conflicts, labelled by driver.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{"driver"},
 	)
 
 	GetNodeHintDuration = metrics.NewHistogramVec(

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -179,6 +179,10 @@ var (
 	DRABindingConditionsAllocationsTotal *metrics.CounterVec
 	DRABindingConditionsPreBindDuration  *metrics.HistogramVec
 
+	// DRACompatibilityGroupRejectionsTotal is only available when the
+	// DRADeviceCompatibilityGroups feature gate is enabled.
+	DRACompatibilityGroupRejectionsTotal *metrics.CounterVec
+
 	// metricsList is a list of all metrics that should be registered always, regardless of any feature gate's value.
 	metricsList []metrics.Registerable
 )
@@ -218,6 +222,9 @@ func Register() {
 				DRABindingConditionsAllocationsTotal,
 				DRABindingConditionsPreBindDuration,
 			)
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceCompatibilityGroups) {
+			RegisterMetrics(DRACompatibilityGroupRejectionsTotal)
 		}
 	})
 }
@@ -482,6 +489,16 @@ func InitMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"profile", "driver", "status"},
+	)
+
+	DRACompatibilityGroupRejectionsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "dra_compatibility_rejections_total",
+			Help:           "Number of DRA candidate-device rejections caused by compatibility-group conflicts, labelled by driver and counter set.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"driver", "counter_set"},
 	)
 
 	GetNodeHintDuration = metrics.NewHistogramVec(

--- a/staging/src/k8s.io/api/resource/v1/generated.pb.go
+++ b/staging/src/k8s.io/api/resource/v1/generated.pb.go
@@ -1387,6 +1387,15 @@ func (m *DeviceCounterConsumption) MarshalToSizedBuffer(dAtA []byte) (int, error
 	_ = i
 	var l int
 	_ = l
+	if len(m.CompatibilityGroups) > 0 {
+		for iNdEx := len(m.CompatibilityGroups) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.CompatibilityGroups[iNdEx])
+			copy(dAtA[i:], m.CompatibilityGroups[iNdEx])
+			i = encodeVarintGenerated(dAtA, i, uint64(len(m.CompatibilityGroups[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.Counters) > 0 {
 		keysForCounters := make([]string, 0, len(m.Counters))
 		for k := range m.Counters {
@@ -3129,6 +3138,12 @@ func (m *DeviceCounterConsumption) Size() (n int) {
 			n += mapEntrySize + 1 + sovGenerated(uint64(mapEntrySize))
 		}
 	}
+	if len(m.CompatibilityGroups) > 0 {
+		for _, s := range m.CompatibilityGroups {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -3968,6 +3983,7 @@ func (this *DeviceCounterConsumption) String() string {
 	s := strings.Join([]string{`&DeviceCounterConsumption{`,
 		`CounterSet:` + fmt.Sprintf("%v", this.CounterSet) + `,`,
 		`Counters:` + mapStringForCounters + `,`,
+		`CompatibilityGroups:` + fmt.Sprintf("%v", this.CompatibilityGroups) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -8268,6 +8284,38 @@ func (m *DeviceCounterConsumption) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Counters[mapkey] = *mapvalue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompatibilityGroups", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CompatibilityGroups = append(m.CompatibilityGroups, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -894,6 +894,21 @@ message DeviceCounterConsumption {
   // +k8s:alpha(since: "1.36")=+k8s:required
   // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
+
+  // CompatibilityGroups lists names of mutually-compatible groups this
+  // device belongs to for the referenced counter set. Two devices
+  // consuming from the same counter set can be co-allocated only if
+  // they share at least one group name, or if both omit the field.
+  //
+  // The relation is symmetric but not transitive.
+  // Group names are driver-defined; no cluster-wide registry is enforced.
+  //
+  // The maximum number of groups per entry is 8.
+  //
+  // +optional
+  // +listType=atomic
+  // +featureGate=DRADeviceCompatibilityGroups
+  repeated string compatibilityGroups = 3;
 }
 
 // DeviceRequest is a request for devices required for a claim.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -312,6 +312,10 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
 
+// Defines the maximum number of compatibility groups that can be
+// declared per device counter consumption.
+const ResourceSliceMaxCompatibilityGroupsPerConsumption = 8
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -535,6 +539,21 @@ type DeviceCounterConsumption struct {
 	// +k8s:alpha(since: "1.36")=+k8s:required
 	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
+
+	// CompatibilityGroups lists names of mutually-compatible groups this
+	// device belongs to for the referenced counter set. Two devices
+	// consuming from the same counter set can be co-allocated only if
+	// they share at least one group name, or if both omit the field.
+	//
+	// The relation is symmetric but not transitive.
+	// Group names are driver-defined; no cluster-wide registry is enforced.
+	//
+	// The maximum number of groups per entry is 8.
+	//
+	// +optional
+	// +listType=atomic
+	// +featureGate=DRADeviceCompatibilityGroups
+	CompatibilityGroups []string `json:"compatibilityGroups,omitempty" protobuf:"bytes,3,rep,name=compatibilityGroups"`
 }
 
 // DeviceCapacity describes a quantity associated with a device.

--- a/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
@@ -259,9 +259,10 @@ func (DeviceConstraint) SwaggerDoc() map[string]string {
 }
 
 var map_DeviceCounterConsumption = map[string]string{
-	"":           "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
-	"counterSet": "CounterSet is the name of the set from which the counters defined will be consumed.",
-	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+	"":                    "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
+	"counterSet":          "CounterSet is the name of the set from which the counters defined will be consumed.",
+	"counters":            "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+	"compatibilityGroups": "CompatibilityGroups lists names of mutually-compatible groups this device belongs to for the referenced counter set. Two devices consuming from the same counter set can be co-allocated only if they share at least one group name, or if both omit the field.\n\nThe relation is symmetric but not transitive. Group names are driver-defined; no cluster-wide registry is enforced.\n\nThe maximum number of groups per entry is 8.",
 }
 
 func (DeviceCounterConsumption) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/resource/v1/zz_generated.deepcopy.go
@@ -685,6 +685,11 @@ func (in *DeviceCounterConsumption) DeepCopyInto(out *DeviceCounterConsumption) 
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.CompatibilityGroups != nil {
+		in, out := &in.CompatibilityGroups, &out.CompatibilityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.pb.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.pb.go
@@ -1422,6 +1422,15 @@ func (m *DeviceCounterConsumption) MarshalToSizedBuffer(dAtA []byte) (int, error
 	_ = i
 	var l int
 	_ = l
+	if len(m.CompatibilityGroups) > 0 {
+		for iNdEx := len(m.CompatibilityGroups) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.CompatibilityGroups[iNdEx])
+			copy(dAtA[i:], m.CompatibilityGroups[iNdEx])
+			i = encodeVarintGenerated(dAtA, i, uint64(len(m.CompatibilityGroups[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.Counters) > 0 {
 		keysForCounters := make([]string, 0, len(m.Counters))
 		for k := range m.Counters {
@@ -3138,6 +3147,12 @@ func (m *DeviceCounterConsumption) Size() (n int) {
 			n += mapEntrySize + 1 + sovGenerated(uint64(mapEntrySize))
 		}
 	}
+	if len(m.CompatibilityGroups) > 0 {
+		for _, s := range m.CompatibilityGroups {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -3970,6 +3985,7 @@ func (this *DeviceCounterConsumption) String() string {
 	s := strings.Join([]string{`&DeviceCounterConsumption{`,
 		`CounterSet:` + fmt.Sprintf("%v", this.CounterSet) + `,`,
 		`Counters:` + mapStringForCounters + `,`,
+		`CompatibilityGroups:` + fmt.Sprintf("%v", this.CompatibilityGroups) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -8346,6 +8362,38 @@ func (m *DeviceCounterConsumption) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Counters[mapkey] = *mapvalue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompatibilityGroups", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CompatibilityGroups = append(m.CompatibilityGroups, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -902,6 +902,21 @@ message DeviceCounterConsumption {
   // +k8s:alpha(since: "1.36")=+k8s:required
   // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
+
+  // CompatibilityGroups lists names of mutually-compatible groups this
+  // device belongs to for the referenced counter set. Two devices
+  // consuming from the same counter set can be co-allocated only if
+  // they share at least one group name, or if both omit the field.
+  //
+  // The relation is symmetric but not transitive.
+  // Group names are driver-defined; no cluster-wide registry is enforced.
+  //
+  // The maximum number of groups per entry is 8.
+  //
+  // +optional
+  // +listType=atomic
+  // +featureGate=DRADeviceCompatibilityGroups
+  repeated string compatibilityGroups = 3;
 }
 
 // DeviceRequest is a request for devices required for a claim.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -305,6 +305,10 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
 
+// Defines the maximum number of compatibility groups that can be
+// declared per device counter consumption.
+const ResourceSliceMaxCompatibilityGroupsPerConsumption = 8
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -537,6 +541,21 @@ type DeviceCounterConsumption struct {
 	// +k8s:alpha(since: "1.36")=+k8s:required
 	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
+
+	// CompatibilityGroups lists names of mutually-compatible groups this
+	// device belongs to for the referenced counter set. Two devices
+	// consuming from the same counter set can be co-allocated only if
+	// they share at least one group name, or if both omit the field.
+	//
+	// The relation is symmetric but not transitive.
+	// Group names are driver-defined; no cluster-wide registry is enforced.
+	//
+	// The maximum number of groups per entry is 8.
+	//
+	// +optional
+	// +listType=atomic
+	// +featureGate=DRADeviceCompatibilityGroups
+	CompatibilityGroups []string `json:"compatibilityGroups,omitempty" protobuf:"bytes,3,rep,name=compatibilityGroups"`
 }
 
 // DeviceCapacity describes a quantity associated with a device.

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -268,9 +268,10 @@ func (DeviceConstraint) SwaggerDoc() map[string]string {
 }
 
 var map_DeviceCounterConsumption = map[string]string{
-	"":           "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
-	"counterSet": "CounterSet is the name of the set from which the counters defined will be consumed.",
-	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+	"":                    "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
+	"counterSet":          "CounterSet is the name of the set from which the counters defined will be consumed.",
+	"counters":            "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+	"compatibilityGroups": "CompatibilityGroups lists names of mutually-compatible groups this device belongs to for the referenced counter set. Two devices consuming from the same counter set can be co-allocated only if they share at least one group name, or if both omit the field.\n\nThe relation is symmetric but not transitive. Group names are driver-defined; no cluster-wide registry is enforced.\n\nThe maximum number of groups per entry is 8.",
 }
 
 func (DeviceCounterConsumption) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/zz_generated.deepcopy.go
@@ -706,6 +706,11 @@ func (in *DeviceCounterConsumption) DeepCopyInto(out *DeviceCounterConsumption) 
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.CompatibilityGroups != nil {
+		in, out := &in.CompatibilityGroups, &out.CompatibilityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.pb.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.pb.go
@@ -1397,6 +1397,15 @@ func (m *DeviceCounterConsumption) MarshalToSizedBuffer(dAtA []byte) (int, error
 	_ = i
 	var l int
 	_ = l
+	if len(m.CompatibilityGroups) > 0 {
+		for iNdEx := len(m.CompatibilityGroups) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.CompatibilityGroups[iNdEx])
+			copy(dAtA[i:], m.CompatibilityGroups[iNdEx])
+			i = encodeVarintGenerated(dAtA, i, uint64(len(m.CompatibilityGroups[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.Counters) > 0 {
 		keysForCounters := make([]string, 0, len(m.Counters))
 		for k := range m.Counters {
@@ -3365,6 +3374,12 @@ func (m *DeviceCounterConsumption) Size() (n int) {
 			n += mapEntrySize + 1 + sovGenerated(uint64(mapEntrySize))
 		}
 	}
+	if len(m.CompatibilityGroups) > 0 {
+		for _, s := range m.CompatibilityGroups {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -4287,6 +4302,7 @@ func (this *DeviceCounterConsumption) String() string {
 	s := strings.Join([]string{`&DeviceCounterConsumption{`,
 		`CounterSet:` + fmt.Sprintf("%v", this.CounterSet) + `,`,
 		`Counters:` + mapStringForCounters + `,`,
+		`CompatibilityGroups:` + fmt.Sprintf("%v", this.CompatibilityGroups) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -8653,6 +8669,38 @@ func (m *DeviceCounterConsumption) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Counters[mapkey] = *mapvalue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompatibilityGroups", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CompatibilityGroups = append(m.CompatibilityGroups, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -897,6 +897,21 @@ message DeviceCounterConsumption {
   // +k8s:alpha(since: "1.36")=+k8s:required
   // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
+
+  // CompatibilityGroups lists names of mutually-compatible groups this
+  // device belongs to for the referenced counter set. Two devices
+  // consuming from the same counter set can be co-allocated only if
+  // they share at least one group name, or if both omit the field.
+  //
+  // The relation is symmetric but not transitive.
+  // Group names are driver-defined; no cluster-wide registry is enforced.
+  //
+  // The maximum number of groups per entry is 8.
+  //
+  // +optional
+  // +listType=atomic
+  // +featureGate=DRADeviceCompatibilityGroups
+  repeated string compatibilityGroups = 3;
 }
 
 // DeviceRequest is a request for devices required for a claim.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -297,6 +297,10 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
 
+// Defines the maximum number of compatibility groups that can be
+// declared per device counter consumption.
+const ResourceSliceMaxCompatibilityGroupsPerConsumption = 8
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -520,6 +524,21 @@ type DeviceCounterConsumption struct {
 	// +k8s:alpha(since: "1.36")=+k8s:required
 	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
+
+	// CompatibilityGroups lists names of mutually-compatible groups this
+	// device belongs to for the referenced counter set. Two devices
+	// consuming from the same counter set can be co-allocated only if
+	// they share at least one group name, or if both omit the field.
+	//
+	// The relation is symmetric but not transitive.
+	// Group names are driver-defined; no cluster-wide registry is enforced.
+	//
+	// The maximum number of groups per entry is 8.
+	//
+	// +optional
+	// +listType=atomic
+	// +featureGate=DRADeviceCompatibilityGroups
+	CompatibilityGroups []string `json:"compatibilityGroups,omitempty" protobuf:"bytes,3,rep,name=compatibilityGroups"`
 }
 
 // DeviceCapacity describes a quantity associated with a device.

--- a/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
@@ -259,9 +259,10 @@ func (DeviceConstraint) SwaggerDoc() map[string]string {
 }
 
 var map_DeviceCounterConsumption = map[string]string{
-	"":           "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
-	"counterSet": "CounterSet is the name of the set from which the counters defined will be consumed.",
-	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+	"":                    "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
+	"counterSet":          "CounterSet is the name of the set from which the counters defined will be consumed.",
+	"counters":            "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+	"compatibilityGroups": "CompatibilityGroups lists names of mutually-compatible groups this device belongs to for the referenced counter set. Two devices consuming from the same counter set can be co-allocated only if they share at least one group name, or if both omit the field.\n\nThe relation is symmetric but not transitive. Group names are driver-defined; no cluster-wide registry is enforced.\n\nThe maximum number of groups per entry is 8.",
 }
 
 func (DeviceCounterConsumption) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta2/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/zz_generated.deepcopy.go
@@ -685,6 +685,11 @@ func (in *DeviceCounterConsumption) DeepCopyInto(out *DeviceCounterConsumption) 
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.CompatibilityGroups != nil {
+		in, out := &in.CompatibilityGroups, &out.CompatibilityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/types.go
@@ -76,6 +76,7 @@ type Device struct {
 }
 
 type DeviceCounterConsumption struct {
-	CounterSet UniqueString
-	Counters   map[string]resourceapi.Counter `json:",omitempty"`
+	CounterSet          UniqueString
+	Counters            map[string]resourceapi.Counter `json:",omitempty"`
+	CompatibilityGroups []string                       `json:",omitempty"`
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/zz_generated.conversion.go
@@ -1006,6 +1006,7 @@ func Convert_v1beta1_DeviceConstraint_To_v1_DeviceConstraint(in *resourcev1beta1
 func autoConvert_v1_DeviceCounterConsumption_To_v1beta1_DeviceCounterConsumption(in *v1.DeviceCounterConsumption, out *resourcev1beta1.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resourcev1beta1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 
@@ -1017,6 +1018,7 @@ func Convert_v1_DeviceCounterConsumption_To_v1beta1_DeviceCounterConsumption(in 
 func autoConvert_v1beta1_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in *resourcev1beta1.DeviceCounterConsumption, out *v1.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta2/zz_generated.conversion.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta2/zz_generated.conversion.go
@@ -1017,6 +1017,7 @@ func Convert_v1beta2_DeviceConstraint_To_v1_DeviceConstraint(in *resourcev1beta2
 func autoConvert_v1_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumption(in *v1.DeviceCounterConsumption, out *resourcev1beta2.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]resourcev1beta2.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 
@@ -1028,6 +1029,7 @@ func Convert_v1_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumption(in 
 func autoConvert_v1beta2_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in *resourcev1beta2.DeviceCounterConsumption, out *v1.DeviceCounterConsumption, s conversion.Scope) error {
 	out.CounterSet = in.CounterSet
 	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/zz_generated.conversion.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/zz_generated.conversion.go
@@ -214,6 +214,7 @@ func autoConvert_api_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in 
 		return err
 	}
 	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 
@@ -227,6 +228,7 @@ func autoConvert_v1_DeviceCounterConsumption_To_api_DeviceCounterConsumption(in 
 		return err
 	}
 	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	out.CompatibilityGroups = *(*[]string)(unsafe.Pointer(&in.CompatibilityGroups))
 	return nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -83,6 +83,18 @@ func NewDeviceConsumedCapacity(deviceID DeviceID,
 	return schedulerapi.NewDeviceConsumedCapacity(deviceID, consumedCapacity)
 }
 
+// SetCompatibilityGroupRejectionRecorder wires a callback that the
+// experimental allocator invokes whenever a candidate device is rejected
+// due to a compatibility-group conflict (KEP-5963). The scheduler uses
+// this to emit the dra_compatibility_rejections_total metric. Outside
+// the scheduler the default no-op recorder applies.
+func SetCompatibilityGroupRejectionRecorder(fn func(driver, counterSet string)) {
+	if fn == nil {
+		fn = func(string, string) {}
+	}
+	experimental.CompatibilityGroupRejectionRecorder = fn
+}
+
 // Allocator calculates how to allocate a set of unallocated claims which use
 // structured parameters.
 //

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -88,9 +88,9 @@ func NewDeviceConsumedCapacity(deviceID DeviceID,
 // due to a compatibility-group conflict (KEP-5963). The scheduler uses
 // this to emit the dra_compatibility_rejections_total metric. Outside
 // the scheduler the default no-op recorder applies.
-func SetCompatibilityGroupRejectionRecorder(fn func(driver, counterSet string)) {
+func SetCompatibilityGroupRejectionRecorder(fn func(driver string)) {
 	if fn == nil {
-		fn = func(string, string) {}
+		fn = func(string) {}
 	}
 	experimental.CompatibilityGroupRejectionRecorder = fn
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -83,18 +83,6 @@ func NewDeviceConsumedCapacity(deviceID DeviceID,
 	return schedulerapi.NewDeviceConsumedCapacity(deviceID, consumedCapacity)
 }
 
-// SetCompatibilityGroupRejectionRecorder wires a callback that the
-// experimental allocator invokes whenever a candidate device is rejected
-// due to a compatibility-group conflict (KEP-5963). The scheduler uses
-// this to emit the dra_compatibility_rejections_total metric. Outside
-// the scheduler the default no-op recorder applies.
-func SetCompatibilityGroupRejectionRecorder(fn func(driver string)) {
-	if fn == nil {
-		fn = func(string) {}
-	}
-	experimental.CompatibilityGroupRejectionRecorder = fn
-}
-
 // Allocator calculates how to allocate a set of unallocated claims which use
 // structured parameters.
 //

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -85,16 +85,6 @@ var SupportedFeatures = internal.Features{
 	DeviceCompatibilityGroups: true,
 }
 
-// CompatibilityGroupRejectionRecorder is invoked from the allocator when a
-// device candidate is rejected because of a compatibility-group conflict
-// (KEP-5963). The scheduler wires this to a metrics counter; in unit tests
-// and when the feature is disabled it is a no-op.
-var CompatibilityGroupRejectionRecorder = func(driver string) {}
-
-func recordCompatibilityGroupRejection(device deviceWithID) {
-	CompatibilityGroupRejectionRecorder(device.pool.PoolID.Driver.String())
-}
-
 type Allocator struct {
 	features       Features
 	allocatedState AllocatedState
@@ -1501,7 +1491,6 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		if !ok {
 			alloc.logger.V(7).Info("Device rejected by compatibility groups", "device", device.id)
 			alloc.deallocateCountersForDevice(device)
-			recordCompatibilityGroupRejection(device)
 			return false, nil, nil
 		}
 		compatRollbacks = rb

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -75,13 +75,29 @@ func NewConsumedCapacityCollection() ConsumedCapacityCollection {
 // making this the variant that is used when any of those
 // are enabled.
 var SupportedFeatures = internal.Features{
-	AdminAccess:            true,
-	PrioritizedList:        true,
-	PartitionableDevices:   true,
-	DeviceTaints:           true,
-	DeviceBindingAndStatus: true,
-	ConsumableCapacity:     true,
-	ListTypeAttributes:     true,
+	AdminAccess:               true,
+	PrioritizedList:           true,
+	PartitionableDevices:      true,
+	DeviceTaints:              true,
+	DeviceBindingAndStatus:    true,
+	ConsumableCapacity:        true,
+	ListTypeAttributes:        true,
+	DeviceCompatibilityGroups: true,
+}
+
+// CompatibilityGroupRejectionRecorder is invoked from the allocator when a
+// device candidate is rejected because of a compatibility-group conflict
+// (KEP-5963). The scheduler wires this to a metrics counter; in unit tests
+// and when the feature is disabled it is a no-op.
+var CompatibilityGroupRejectionRecorder = func(driver, counterSet string) {}
+
+func recordCompatibilityGroupRejection(device deviceWithID) {
+	driver := device.pool.PoolID.Driver.String()
+	counterSet := ""
+	if len(device.ConsumesCounters) > 0 {
+		counterSet = device.ConsumesCounters[0].CounterSet.String()
+	}
+	CompatibilityGroupRejectionRecorder(driver, counterSet)
 }
 
 type Allocator struct {
@@ -159,6 +175,7 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 		deviceMatchesRequest: make(map[matchKey]bool),
 		constraints:          make([][]constraint, len(claims)),
 		consumedCounters:     make(map[draapi.UniqueString]counterSets),
+		groupsPerCounterSet:  make(map[draapi.UniqueString]map[draapi.UniqueString]compatState),
 		requestData:          make(map[requestIndices]requestData),
 		result:               make([]internalAllocationResult, len(claims)),
 		allocatingCapacity:   NewConsumedCapacityCollection(),
@@ -623,7 +640,11 @@ type allocator struct {
 	// that are in the process of being allocated.
 	// The keys in the map are resource pool names.
 	consumedCounters map[draapi.UniqueString]counterSets
-	requestData      map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
+	// groupsPerCounterSet tracks compatibility-group state (KEP-5963)
+	// during one allocation attempt. Outer key is pool name; inner key
+	// is counter-set name.
+	groupsPerCounterSet map[draapi.UniqueString]map[draapi.UniqueString]compatState
+	requestData         map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
 	// allocatingDevices tracks which devices will be newly allocated for a
 	// particular attempt to find a solution. The map is indexed by device
 	// and its values represent for which of a pod's claims the device will
@@ -1476,6 +1497,21 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		}
 	}
 
+	// Compatibility-group enforcement (KEP-5963). Devices on the same
+	// counter set can only be co-allocated when their declared
+	// compatibility-group sets intersect (or both omit the field).
+	var compatRollbacks []compatRollback
+	if alloc.features.DeviceCompatibilityGroups && !skipCounterCheck && len(device.ConsumesCounters) > 0 {
+		ok, rb := alloc.checkCompatibilityGroups(device)
+		if !ok {
+			alloc.logger.V(7).Info("Device rejected by compatibility groups", "device", device.id)
+			alloc.deallocateCountersForDevice(device)
+			recordCompatibilityGroupRejection(device)
+			return false, nil, nil
+		}
+		compatRollbacks = rb
+	}
+
 	var parentRequestName string
 	var baseRequestName string
 	var subRequestName string
@@ -1579,6 +1615,9 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 			if alloc.features.PartitionableDevices && len(device.ConsumesCounters) > 0 {
 				alloc.deallocateCountersForDevice(device)
 			}
+		}
+		if len(compatRollbacks) > 0 {
+			alloc.rollbackCompatibilityGroups(compatRollbacks)
 		}
 		// Truncate, but keep the underlying slice.
 		alloc.result[r.claimIndex].devices = alloc.result[r.claimIndex].devices[:previousNumResults]
@@ -1943,4 +1982,115 @@ func containsNodeSelectorRequirement(requirements []v1.NodeSelectorRequirement, 
 		return true
 	}
 	return false
+}
+
+// compatState tracks the running compatibility-group state for a single
+// (pool, counterSet) during one allocation attempt. See checkCompatibilityGroups.
+type compatState struct {
+	// groups is the intersection of compatibility groups declared by
+	// allocating devices on this counter set so far. nil means "no
+	// grouped device has joined yet".
+	groups sets.Set[string]
+	// ungroupedSeen is true once a device with no compatibility groups
+	// has been added; further grouped devices on the same counter set
+	// are then incompatible.
+	ungroupedSeen bool
+	// devices counts how many allocating devices currently contribute
+	// to this state.
+	devices int
+}
+
+// compatRollback captures the per-counter-set state that
+// checkCompatibilityGroups overwrote, so a rollback can restore exactly
+// what was there before the device was folded in.
+type compatRollback struct {
+	pool       draapi.UniqueString
+	counterSet draapi.UniqueString
+	prev       compatState
+	existed    bool
+}
+
+// checkCompatibilityGroups returns true iff `device` is compatible with
+// the devices already being allocated on every counter set it consumes.
+// On success it folds the device's groups into the running state and
+// returns a list of per-counter-set rollback entries that the caller
+// must apply with rollbackCompatibilityGroups on failure of a later
+// step. On failure it leaves the running state unchanged.
+//
+// Rules (KEP-5963):
+//   - both ungrouped -> compatible
+//   - one ungrouped, one grouped -> incompatible
+//   - both grouped -> intersection must be non-empty
+func (alloc *allocator) checkCompatibilityGroups(device deviceWithID) (bool, []compatRollback) {
+	poolName := device.pool.PoolID.Pool
+	poolState, ok := alloc.groupsPerCounterSet[poolName]
+	if !ok {
+		poolState = make(map[draapi.UniqueString]compatState)
+	}
+	// First pass: validate without mutating.
+	for _, dcc := range device.ConsumesCounters {
+		st := poolState[dcc.CounterSet]
+		deviceHasGroups := len(dcc.CompatibilityGroups) > 0
+		if !deviceHasGroups {
+			if st.groups != nil {
+				return false, nil
+			}
+			continue
+		}
+		if st.ungroupedSeen {
+			return false, nil
+		}
+		if st.groups != nil {
+			deviceSet := sets.New(dcc.CompatibilityGroups...)
+			if st.groups.Intersection(deviceSet).Len() == 0 {
+				return false, nil
+			}
+		}
+	}
+	// Second pass: commit, recording the prior state for rollback.
+	rollbacks := make([]compatRollback, 0, len(device.ConsumesCounters))
+	for _, dcc := range device.ConsumesCounters {
+		prev, existed := poolState[dcc.CounterSet]
+		rollbacks = append(rollbacks, compatRollback{
+			pool:       poolName,
+			counterSet: dcc.CounterSet,
+			prev:       prev,
+			existed:    existed,
+		})
+		st := prev
+		st.devices++
+		if len(dcc.CompatibilityGroups) == 0 {
+			st.ungroupedSeen = true
+			poolState[dcc.CounterSet] = st
+			continue
+		}
+		deviceSet := sets.New(dcc.CompatibilityGroups...)
+		if st.groups == nil {
+			st.groups = deviceSet
+		} else {
+			st.groups = st.groups.Intersection(deviceSet)
+		}
+		poolState[dcc.CounterSet] = st
+	}
+	alloc.groupsPerCounterSet[poolName] = poolState
+	return true, rollbacks
+}
+
+// rollbackCompatibilityGroups restores the per-counter-set states that
+// the matching checkCompatibilityGroups call had overwritten.
+func (alloc *allocator) rollbackCompatibilityGroups(rollbacks []compatRollback) {
+	for _, rb := range rollbacks {
+		poolState, ok := alloc.groupsPerCounterSet[rb.pool]
+		if !ok {
+			continue
+		}
+		if rb.existed {
+			poolState[rb.counterSet] = rb.prev
+		} else {
+			delete(poolState, rb.counterSet)
+		}
+		if len(poolState) == 0 {
+			delete(alloc.groupsPerCounterSet, rb.pool)
+		}
+	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -89,15 +89,10 @@ var SupportedFeatures = internal.Features{
 // device candidate is rejected because of a compatibility-group conflict
 // (KEP-5963). The scheduler wires this to a metrics counter; in unit tests
 // and when the feature is disabled it is a no-op.
-var CompatibilityGroupRejectionRecorder = func(driver, counterSet string) {}
+var CompatibilityGroupRejectionRecorder = func(driver string) {}
 
 func recordCompatibilityGroupRejection(device deviceWithID) {
-	driver := device.pool.PoolID.Driver.String()
-	counterSet := ""
-	if len(device.ConsumesCounters) > 0 {
-		counterSet = device.ConsumesCounters[0].CounterSet.String()
-	}
-	CompatibilityGroupRejectionRecorder(driver, counterSet)
+	CompatibilityGroupRejectionRecorder(device.pool.PoolID.Driver.String())
 }
 
 type Allocator struct {
@@ -1713,6 +1708,15 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 			}
 		}
 
+		// Seed compatibility-group state (KEP-5963) from devices already
+		// allocated by prior claims. Runs once per pool, in the same
+		// lazy-init block as the counter cache, so the work is amortised
+		// and the seeded state is in place before any per-device compat
+		// check fires for this pool.
+		if alloc.features.DeviceCompatibilityGroups {
+			alloc.seedCompatibilityGroupsFromAllocated(pool)
+		}
+
 		// Set the available counters on the allocator so we don't have to
 		// compute this again.
 		alloc.mutex.Lock()
@@ -1995,9 +1999,6 @@ type compatState struct {
 	// has been added; further grouped devices on the same counter set
 	// are then incompatible.
 	ungroupedSeen bool
-	// devices counts how many allocating devices currently contribute
-	// to this state.
-	devices int
 }
 
 // compatRollback captures the per-counter-set state that
@@ -2058,7 +2059,6 @@ func (alloc *allocator) checkCompatibilityGroups(device deviceWithID) (bool, []c
 			existed:    existed,
 		})
 		st := prev
-		st.devices++
 		if len(dcc.CompatibilityGroups) == 0 {
 			st.ungroupedSeen = true
 			poolState[dcc.CounterSet] = st
@@ -2092,5 +2092,76 @@ func (alloc *allocator) rollbackCompatibilityGroups(rollbacks []compatRollback) 
 		if len(poolState) == 0 {
 			delete(alloc.groupsPerCounterSet, rb.pool)
 		}
+	}
+}
+
+// seedCompatibilityGroupsFromAllocated folds compatibility-group state
+// from devices already allocated in `pool` (per alloc.allocatedState)
+// into alloc.groupsPerCounterSet, so cross-claim conflicts on the same
+// pool/counterSet are caught when later devices are checked.
+//
+// Idempotent for a given pool because the caller invokes it once per
+// pool from the same lazy-init block that populates availableCounters.
+func (alloc *allocator) seedCompatibilityGroupsFromAllocated(pool *Pool) {
+	poolName := pool.PoolID.Pool
+	var poolState map[draapi.UniqueString]compatState
+	for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
+		for _, slice := range resourceSlices {
+			for _, device := range slice.Spec.Devices {
+				deviceID := DeviceID{
+					Driver: slice.Spec.Driver,
+					Pool:   slice.Spec.Pool.Name,
+					Device: device.Name,
+				}
+				if !alloc.allocatedState.AllocatedDevices.Has(deviceID) {
+					continue
+				}
+				for _, dcc := range device.ConsumesCounters {
+					if poolState == nil {
+						poolState = make(map[draapi.UniqueString]compatState)
+					}
+					st := poolState[dcc.CounterSet]
+					if len(dcc.CompatibilityGroups) == 0 {
+						st.ungroupedSeen = true
+					} else {
+						ds := sets.New(dcc.CompatibilityGroups...)
+						if st.groups == nil {
+							st.groups = ds
+						} else {
+							st.groups = st.groups.Intersection(ds)
+						}
+					}
+					poolState[dcc.CounterSet] = st
+				}
+			}
+		}
+	}
+	if poolState == nil {
+		return
+	}
+	alloc.mutex.Lock()
+	defer alloc.mutex.Unlock()
+	existing, ok := alloc.groupsPerCounterSet[poolName]
+	if !ok {
+		alloc.groupsPerCounterSet[poolName] = poolState
+		return
+	}
+	// Merge: persisted seed wins for fresh counterSets; for counterSets
+	// already touched by an in-flight allocating device, intersect.
+	for cs, seed := range poolState {
+		cur, present := existing[cs]
+		if !present {
+			existing[cs] = seed
+			continue
+		}
+		if seed.ungroupedSeen {
+			cur.ungroupedSeen = true
+		}
+		if cur.groups == nil {
+			cur.groups = seed.groups
+		} else if seed.groups != nil {
+			cur.groups = cur.groups.Intersection(seed.groups)
+		}
+		existing[cs] = cur
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
@@ -77,13 +77,14 @@ const (
 type Features struct {
 	// Sorted alphabetically. When adding a new entry, also extend Set and FeaturesAll.
 
-	AdminAccess            bool
-	ConsumableCapacity     bool
-	DeviceBindingAndStatus bool
-	DeviceTaints           bool
-	ListTypeAttributes     bool
-	PartitionableDevices   bool
-	PrioritizedList        bool
+	AdminAccess               bool
+	ConsumableCapacity        bool
+	DeviceBindingAndStatus    bool
+	DeviceCompatibilityGroups bool
+	DeviceTaints              bool
+	ListTypeAttributes        bool
+	PartitionableDevices      bool
+	PrioritizedList           bool
 }
 
 // Set returns all features which are set to true.
@@ -115,15 +116,19 @@ func (f Features) Set() sets.Set[string] {
 	if f.DeviceBindingAndStatus {
 		enabled.Insert("DRADeviceBindingConditions+DRAResourceClaimDeviceStatus")
 	}
+	if f.DeviceCompatibilityGroups {
+		enabled.Insert("DRADeviceCompatibilityGroups")
+	}
 	return enabled
 }
 
 var FeaturesAll = Features{
-	AdminAccess:            true,
-	ConsumableCapacity:     true,
-	DeviceBindingAndStatus: true,
-	DeviceTaints:           true,
-	ListTypeAttributes:     true,
-	PartitionableDevices:   true,
-	PrioritizedList:        true,
+	AdminAccess:               true,
+	ConsumableCapacity:        true,
+	DeviceBindingAndStatus:    true,
+	DeviceCompatibilityGroups: true,
+	DeviceTaints:              true,
+	ListTypeAttributes:        true,
+	PartitionableDevices:      true,
+	PrioritizedList:           true,
 }


### PR DESCRIPTION
<!-- repo-watcher:bot -->
## Summary

Alpha implementation of **KEP-5963 - DRA Device Compatibility Groups** behind feature gate `DRADeviceCompatibilityGroups` (default off). Follows the merged plan in #1.

## What this PR does

- **API** - adds optional `compatibilityGroups []string` to `DeviceCounterConsumption` in `resource.k8s.io/{v1,v1beta1,v1beta2}`, the internal type, and the scheduler-side `draapi` mirror; adds `ResourceSliceMaxCompatibilityGroupsPerConsumption = 8`.
- **Feature gate** - `DRADeviceCompatibilityGroups` registered in `pkg/features/kube_features.go` (alpha @ 1.37, default off, depends on `DynamicResourceAllocation` + `DRAPartitionableDevices`). Wired through the scheduler `feature.Features` and into `structured.Features` as `DeviceCompatibilityGroups`.
- **Strategy / drop-disabled** - `dropDisabledDRADeviceCompatibilityGroupsFields` strips the field on writes when the gate is off, with the usual ratchet on `oldSlice` so existing data is preserved on downgrade.
- **Validation** - `validateDeviceCounterConsumption` validates the new slice when non-empty: max 8 entries, DNS-label names, no duplicates.
- **Allocator** - the experimental structured-allocator variant marks `DeviceCompatibilityGroups: true` in `SupportedFeatures`, so the router at `structured/allocator.go` picks experimental whenever the bit is set (stable & incubating untouched until graduation, per the plan). `allocateDevice` runs an intersection check after the counter-availability check; mismatches roll back the counter accounting, increment the metric, and reject the candidate. State is per-pool/per-counter-set with snapshot-based rollback so backtracking restores the prior state exactly.
- **Metric** - `scheduler_dra_compatibility_rejections_total{driver,counter_set}` (alpha) registered conditionally on the gate; the scheduler plugin wires it to a callback exposed by `structured.SetCompatibilityGroupRejectionRecorder`, keeping the staging package free of `pkg/scheduler/metrics`.
- **Generated code** - manually mirrored the field add in the `zz_generated.deepcopy.go` files and the relevant `zz_generated.conversion.go` files for what `go build ./...` exercises today. `update-codegen.sh` should still be run before merge to refresh protobuf marshalers, OpenAPI specs, swagger docs, and declarative validations.

## Verification

- `go build ./...` passes.
- `go vet` passes for the touched packages.
- Tests deferred per the plan - unit/integration coverage will land in a follow-up once the API surface is stable. The plan calls for `validation_resourceslice_test.go`, strategy ratchet cases, allocator-matrix tests in `allocatortesting/`, and a `test/integration/dra/compatibility_groups.go`.

## Out of scope

- e2e tests (deferred to beta per the KEP).
- `update-codegen.sh` regeneration of protobuf, OpenAPI, swagger doc, and declarative-validation artifacts - needs to be run by a maintainer with the codegen toolchain.
- Beta/GA graduation, cross-counter-set compatibility, cluster-wide group-name registry (KEP non-goals).

Implements #4. Plan: #1.
